### PR TITLE
[EPM-4370]: Add USB1 VBUS power regulator overlay

### DIFF
--- a/package/extra-dts/BB-USB1-VBUS-POWER.dts
+++ b/package/extra-dts/BB-USB1-VBUS-POWER.dts
@@ -1,0 +1,50 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+    /* Pinmux for USB1_DRVVBUS (gpio3_13) */
+    fragment@0 {
+        target = <&am33xx_pinmux>;
+        __overlay__ {
+            usb1_vbus_pins: pinmux_usb1_vbus_pins {
+                pinctrl-single,pins = <
+                    0x0f4 0x07  /* usb1_drvvbus, MODE7 | OUTPUT */
+                >;
+            };
+        };
+    };
+
+    /* Fixed 5V regulator for USB1 VBUS */
+    fragment@1 {
+        target-path = "/";
+        __overlay__ {
+            usb1_vbus: regulator-usb1-vbus {
+                compatible = "regulator-fixed";
+                regulator-name = "usb1_vbus";
+                regulator-min-microvolt = <5000000>;
+                regulator-max-microvolt = <5000000>;
+                regulator-max-microamp = <500000>;
+
+                pinctrl-names = "default";
+                pinctrl-0 = <&usb1_vbus_pins>;
+
+                gpio = <&gpio3 13 GPIO_ACTIVE_LOW>;
+                enable-active-low;
+
+                /* optional */
+                /* regulator-always-on; */
+            };
+        };
+    };
+
+    /* USB1 controller */
+    fragment@2 {
+        target = <&usb1>;
+        __overlay__ {
+            dr_mode = "host";
+            vbus-supply = <&usb1_vbus>;
+        };
+    };
+};


### PR DESCRIPTION
- Configures GPIO3_13 (USB1_DRVVBUS) pinmux and creates fixed 5V regulator with 500mA max current
- Links regulator to USB1 controller to fix "insufficient available bus power" errors