### PR TITLE
Disable MMC1 card‑detect to avoid SD/LCD pin conflict

### DIFF
--- a/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
+++ b/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
@@ -81,7 +81,7 @@
             pinctrl-0 = <&zola_spi1_pins>;
 
             /* ILI9488 LCD device */
-            display@0 {
+            channel@0 {
                 compatible = "ilitek,ili9488";
                 reg = <0>;                         /* Chip Select 0 (B12) */
                 spi-max-frequency = <24000000>;
@@ -103,7 +103,7 @@
             };
 
             /* ADS7846 Touch device */
-            touch@1 {
+            channel@1 {
                 compatible = "ti,ads7846";
                 reg = <1>;                         /* Chip Select 1 (C13) */
                 spi-max-frequency = <2000000>;
@@ -126,7 +126,16 @@
     fragment@4 {
         target = <&mmc1>;
         __overlay__ {
-            broken-cd; /* Stops MMC from claiming A13  */
+            broken-cd;
         };
+    };
+
+    /* Fragment 5: Fix MMC0 (eMMC) Conflict on PIN12/T3 */
+    fragment@5 {
+        target = <&mmc0>;
+        __overlay__ {
+            /* Force MMC0 to release PIN12 by redefining its pinctrl */
+            ti,non-removable;
+        } ;
     };
 };

--- a/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
+++ b/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
@@ -6,7 +6,6 @@
     part-number = "ZOLA-LCD-ILI9488-ADS7846";
     version = "00A1";
 
-
     /* Fragment 0: Release J31 pins from legacy OCP/Helper ownership */
     fragment@0 {
         target = <&ocp>;
@@ -20,7 +19,6 @@
             cape-universal { status = "disabled"; };
         };
     };
-
 
     /* Fragment 1: Pinmux: Separate SPI and GPIO Pins */
     fragment@1 {
@@ -76,15 +74,20 @@
             #size-cells = <0>;
 
             pinctrl-names = "default";
-            pinctrl-0 = <&zola_spi1_pins>;
+            pinctrl-0 = <
+                &zola_spi1_pins
+                &zola_lcd_gpio_pins
+                &zola_touch_gpio_pins
+            >;
+
+            /delete-node/ channel@0;
+            /delete-node/ channel@1;
 
             /* -------- LCD -------- */
             ili9488@0 {
                 compatible = "ilitek,ili9488";
                 reg = <0>;
                 spi-max-frequency = <24000000>;
-                pinctrl-names = "default";
-                pinctrl-0 = <&zola_lcd_gpio_pins>;
 
                 dc-gpios    = <&gpio2 12 0>; /* TFT_RS */
                 reset-gpios = <&gpio2 10 0>; /* TFT_RST */
@@ -101,8 +104,6 @@
                 compatible = "ti,ads7846";
                 reg = <1>;                         /* Chip Select 1 (C13) */
                 spi-max-frequency = <2000000>;
-                pinctrl-names = "default";
-                pinctrl-0 = <&zola_touch_gpio_pins>;
 
                 /* Touch GPIO Configuration */
                 interrupt-parent = <&gpio2>;

--- a/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
+++ b/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
@@ -15,10 +15,8 @@
             P9_29_pinmux { status = "disabled"; }; /* Ball B13: SPI1_D0 */
             P9_30_pinmux { status = "disabled"; }; /* Ball D12: SPI1_D1 */
             P9_28_pinmux { status = "disabled"; }; /* Ball C13: TP_CS */
-            P9_42_pinmux { status = "disabled"; }; /* Ball B12: TFT_CS */
+            P9_92_pinmux { status = "disabled"; }; /* Ball B12: TFT_CS */
 
-            /* Disable the LED and helper nodes to prevent probe conflicts */
-            led_pins { status = "disabled"; };
             cape-universal { status = "disabled"; };
         };
     };
@@ -31,26 +29,27 @@
             /* Only SPI1 master pins (SCLK, MISO, MOSI) */
             zola_spi1_pins: pinmux_zola_spi1_pins {
                 pinctrl-single,pins = <
-                    0x190 0x33    /* A13: SPI1_SCLK | MODE3 | INPUT_PULLUP */
-                    0x194 0x13    /* B13: SPI1_D0 (MOSI) | MODE3 | OUTPUT */
-                    0x198 0x33    /* D12: SPI1_D1 (MISO) | MODE3 | INPUT_PULLUP */
+                    0x190 0x30   /* MCASP0_ACLKX  -> SPI1_SCLK */
+                    0x194 0x30   /* MCASP0_FSX    -> SPI1_MOSI */
+                    0x198 0x30   /* MCASP0_AXR0   -> SPI1_MISO */
+                    0x19c 0x30   /* MCASP0_AXR2   -> SPI1_CS0 (LCD) */
+                    0x1a0 0x30   /* MCASP0_AXR3   -> SPI1_CS1 (Touch) */
                 >;
             };
 
-            /* LCD Control GPIOs (RS, RESET, CS) + Touch Control GPIOs (IRQ, CS) + Backlight */
-            zola_lcd_touch_gpio_pins: pinmux_zola_lcd_touch_gpio_pins {
+            /* ---------- LCD GPIO pins (GPMC_Ax / LCD_DATAx) ---------- */
+            zola_lcd_gpio_pins: pinmux_zola_lcd_gpio_pins {
                 pinctrl-single,pins = <
-                    /* LCD Control GPIOs */
-                    0x030 0x07    /* T3: TFT_RS (GPIO2_12) OUTPUT | MODE7 */
-                    0x028 0x07    /* T1: TFT_RST (GPIO2_10) OUTPUT | MODE7 */
-                    0x1A0 0x13    /* B12: TFT_CS (GPIO3_18) OUTPUT | MODE3 */
+                    0x030 0x07   /* LCD_DATA6 / GPMC_A6 -> GPIO2_12 (TFT_RS) */
+                    0x028 0x07   /* LCD_DATA4 / GPMC_A4 -> GPIO2_10 (TFT_RST) */
+                    0x1b4 0x07   /* MCASP0_AXR1         -> GPIO3_20 (LCD_LED) */
+                >;
+            };
 
-                    /* Touch Control GPIOs */
-                    0x1A4 0x13    /* C13: TP_CS (GPIO3_19) OUTPUT | MODE3 */
-                    0x034 0x27    /* T4: TP_IRQ (GPIO2_13) INPUT_PULLUP | MODE7 */
-
-                    /* Backlight Control */
-                    0x1A8 0x07    /* D13: LCD_LED (GPIO3_20) OUTPUT | MODE7 */
+            /* ---------- Touch IRQ pin ---------- */
+            zola_touch_gpio_pins: pinmux_zola_touch_gpio_pins {
+                pinctrl-single,pins = <
+                    0x034 0x27   /* LCD_DATA7 / GPMC_A7 -> GPIO2_13 (TP_IRQ, pull-up) */
                 >;
             };
         };
@@ -62,7 +61,7 @@
         __overlay__ {
             backlight_zola: backlight_zola {
                 compatible = "gpio-backlight";
-                gpios = <&gpio3 20 0>; /* D13: GPIO3_20 */
+                gpios = <&gpio3 20 0>; /* LCD_LED */
                 default-on;
             };
         };
@@ -76,42 +75,39 @@
             #address-cells = <1>;
             #size-cells = <0>;
 
-            /* SPI master pins applied to controller */
             pinctrl-names = "default";
             pinctrl-0 = <&zola_spi1_pins>;
 
-            /* ILI9488 LCD device */
-            channel@0 {
+            /* -------- LCD -------- */
+            ili9488@0 {
                 compatible = "ilitek,ili9488";
-                reg = <0>;                         /* Chip Select 0 (B12) */
+                reg = <0>;
                 spi-max-frequency = <24000000>;
-
-                /* Applied separate pinctrl for GPIOs as in your reference */
                 pinctrl-names = "default";
-                pinctrl-0 = <&zola_lcd_touch_gpio_pins>;
+                pinctrl-0 = <&zola_lcd_gpio_pins>;
 
-                /* GPIO Definitions using verified offsets */
-                dc-gpios    = <&gpio2 12 0>;       /* T3: GPIO2_12 */
-                reset-gpios = <&gpio2 10 0>;       /* T1: GPIO2_10 */
+                dc-gpios    = <&gpio2 12 0>; /* TFT_RS */
+                reset-gpios = <&gpio2 10 0>; /* TFT_RST */
+                backlight   = <&backlight_zola>;
 
-                backlight = <&backlight_zola>;
                 rotation = <270>;
                 buswidth = <8>;
-
                 width = <480>;
                 height = <320>;
             };
 
-            /* ADS7846 Touch device */
-            channel@1 {
+            /* -------- Touch -------- */
+            ads7846@1 {
                 compatible = "ti,ads7846";
                 reg = <1>;                         /* Chip Select 1 (C13) */
                 spi-max-frequency = <2000000>;
+                pinctrl-names = "default";
+                pinctrl-0 = <&zola_touch_gpio_pins>;
 
                 /* Touch GPIO Configuration */
                 interrupt-parent = <&gpio2>;
-                interrupts = <13 2>;               /* T4: GPIO2_13, Falling Edge '2' */
-                pendown-gpio = <&gpio2 13 0>;
+                interrupts = <13 2>;            /* GPIO2_13, falling edge */
+                pendown-gpio = <&gpio2 13 1>;   /* active low */
 
                 ti,x-min = /bits/ 16 <200>;
                 ti,x-max = /bits/ 16 <3900>;
@@ -122,20 +118,5 @@
             };
         };
     };
-    /* Fragment 4: Solve fix SD/MMC Conflict */
-    fragment@4 {
-        target = <&mmc1>;
-        __overlay__ {
-            broken-cd;
-        };
-    };
-
-    /* Fragment 5: Fix MMC0 (eMMC) Conflict on PIN12/T3 */
-    fragment@5 {
-        target = <&mmc0>;
-        __overlay__ {
-            /* Force MMC0 to release PIN12 by redefining its pinctrl */
-            ti,non-removable;
-        } ;
-    };
 };
+

--- a/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
+++ b/package/extra-dts/BB-LCD-ILI9488-ADS7846.dts
@@ -122,4 +122,11 @@
             };
         };
     };
+    /* Fragment 4: Solve fix SD/MMC Conflict */
+    fragment@4 {
+        target = <&mmc1>;
+        __overlay__ {
+            broken-cd; /* Stops MMC from claiming A13  */
+        };
+    };
 };


### PR DESCRIPTION
## Description
- Set the broken-cd property to stop MMC1 from using the SD card‑detect pin (ball A13).