### PR TITLE
[EPM-3469] Add ILI9488 TFT driver, GPIO monitor, UI dashboard, and LCD backlight on boot

### DIFF
--- a/package/extra-dts/BB-SPIDEV1-00A0_zola.dts
+++ b/package/extra-dts/BB-SPIDEV1-00A0_zola.dts
@@ -53,8 +53,8 @@
 			bb_spi1_pins: pinmux_bb_spi1_pins {
 				pinctrl-single,pins = <
 					0x190 0x13	/* mcasp0_aclkx.spi1_sclk, OUTPUT_PULLUP | MODE3 */
-					0x194 0x33	/* mcasp0_fsx.spi1_d0, INPUT_PULLUP | MODE3 */
-					0x198 0x13	/* mcasp0_axr0.spi1_d1, OUTPUT_PULLUP | MODE3 */
+					0x194 0x33	/* mcasp0_fsx.spi1_d0 (MOSI), OUTPUT_PULLUP | MODE3 */
+					0x198 0x13	/* mcasp0_axr0.spi1_d1 (MISO), INPUT_PULLUP | MODE3 */
 					//0x1A0 0x13	/* mcasp0_ahclkr.spi1_cs0, OUTPUT_PULLUP | MODE3 */
 					// 0x164 0x12	/* eCAP0_in_PWM0_out.spi1_cs1 OUTPUT_PULLUP | MODE2 */
 				>;
@@ -77,7 +77,7 @@
 			 * input. The default is D0 as input and
 			 * D1 as output.
 			 */
-			//ti,pindir-d0-out-d1-in;
+			ti,pindir-d0-out-d1-in;
 
 			channel@0 {
 				#address-cells = <1>;
@@ -88,7 +88,7 @@
 
 				reg = <0>;
 				spi-max-frequency = <16000000>;
-				spi-cpha;
+				//spi-cpha;
 			};
 
 			channel@1 {

--- a/package/extra-dts/BB-SPIDEV1-00A0_zola.dts
+++ b/package/extra-dts/BB-SPIDEV1-00A0_zola.dts
@@ -53,8 +53,8 @@
 			bb_spi1_pins: pinmux_bb_spi1_pins {
 				pinctrl-single,pins = <
 					0x190 0x13	/* mcasp0_aclkx.spi1_sclk, OUTPUT_PULLUP | MODE3 */
-					0x194 0x33	/* mcasp0_fsx.spi1_d0 (MOSI), OUTPUT_PULLUP | MODE3 */
-					0x198 0x13	/* mcasp0_axr0.spi1_d1 (MISO), INPUT_PULLUP | MODE3 */
+					0x194 0x33	/* mcasp0_fsx.spi1_d0, INPUT_PULLUP | MODE3 */
+					0x198 0x13	/* mcasp0_axr0.spi1_d1, OUTPUT_PULLUP | MODE3 */
 					//0x1A0 0x13	/* mcasp0_ahclkr.spi1_cs0, OUTPUT_PULLUP | MODE3 */
 					// 0x164 0x12	/* eCAP0_in_PWM0_out.spi1_cs1 OUTPUT_PULLUP | MODE2 */
 				>;
@@ -77,7 +77,7 @@
 			 * input. The default is D0 as input and
 			 * D1 as output.
 			 */
-			ti,pindir-d0-out-d1-in;
+			//ti,pindir-d0-out-d1-in;
 
 			channel@0 {
 				#address-cells = <1>;
@@ -88,7 +88,7 @@
 
 				reg = <0>;
 				spi-max-frequency = <16000000>;
-				//spi-cpha;
+				spi-cpha;
 			};
 
 			channel@1 {

--- a/test_c2/README.md
+++ b/test_c2/README.md
@@ -23,6 +23,32 @@ To start your Nerves app:
   * Create firmware with `mix firmware`
   * Burn to an SD card with `mix burn`
 
+## Boot behavior
+
+On device boot, the **LCD backlight** (GPIO 116) is set as output and driven high so the display is lit. This is done by `TestC2.LcdBacklight` (`lib/test_c2/lcd_backlight.ex`), started automatically by the application supervisor (targets only, not host).
+
+## ILI9488 TFT modules
+
+Three modules drive the ILI9488 TFT display and a GPIO indicator:
+
+- **Ili9488.Driver** (`lib/test_c2/ili9488_driver.ex`) – SPI/GPIO setup, reset, init, and drawing (fill, rectangles).
+- **Ili9488.GPIOMonitor** (`lib/test_c2/ili9488_gpio_monitor.ex`) – Monitors GPIO 71 and updates the on-screen indicator.
+- **Ili9488.UI** (`lib/test_c2/ili9488_ui.ex`) – Draws the dashboard (blue background, textbox, "GPIO71" label, GPIO indicator).
+
+Full documentation: [docs/ILI9488_MODULES.md](docs/ILI9488_MODULES.md)
+
+### How to run (IEx)
+
+On device (or `iex -S mix` on host):
+
+```elixir
+{:ok, devs} = Ili9488.Driver.start()
+Ili9488.UI.draw_dashboard(devs)
+Ili9488.GPIOMonitor.start(devs)
+```
+
+GPIO 71 is read every 500 ms; the indicator turns green when high and grey when low.
+
 ## Learn more
 
   * Official docs: https://hexdocs.pm/nerves/getting-started.html

--- a/test_c2/docs/ILI9488_MODULES.md
+++ b/test_c2/docs/ILI9488_MODULES.md
@@ -1,0 +1,115 @@
+# ILI9488 TFT Modules
+
+Documentation for the three modules that drive the ILI9488 TFT display and GPIO indicator on the test_c2 Nerves app.
+
+---
+
+## Module overview
+
+| Module | File | Purpose |
+|--------|------|--------|
+| **Ili9488.Driver** | `lib/test_c2/ili9488_driver.ex` | Low-level SPI/GPIO control: open device, reset, init, set window, fill/draw rectangles. |
+| **Ili9488.GPIOMonitor** | `lib/test_c2/ili9488_gpio_monitor.ex` | Background loop that reads GPIO 71 and updates the display when the value changes. |
+| **Ili9488.UI** | `lib/test_c2/ili9488_ui.ex` | Screen layout: dashboard (blue background, textbox, "GPIO71" label, GPIO indicator). |
+
+---
+
+## Ili9488.Driver
+
+**Role:** Hardware interface for the ILI9488 TFT over SPI and GPIO (CS, DC, RST).
+
+**Configuration:**
+- SPI device: `spidev1.0`, mode 0, 8 bits, 20 MHz
+- GPIOs: CS = 114, DC = 76, RST = 74
+- Resolution: 320×480, pixel format RGB666
+
+**Main API:**
+
+| Function | Description |
+|----------|-------------|
+| `start/0` | Opens SPI and GPIOs, resets and initializes the display. Returns `{:ok, devs}`. Pass `devs` into all other drawing functions. |
+| `fill_blue/1` | Fills the entire screen blue. |
+| `fill_color/2` | Fills the entire screen with a given RGB pixel binary (e.g. `<<r, g, b>>`). |
+| `draw_rect/6` | Draws a rectangle at `(x, y)` with size `(w, h)` in the given color. |
+
+**Internals:** Sends the ILI9488 init sequence (soft reset, exit sleep, gamma, power, MADCTL, pixel format, etc.), then uses column/page address and memory-write commands for drawing.
+
+---
+
+## Ili9488.GPIOMonitor
+
+**Role:** Monitors GPIO 71 and refreshes the on-screen GPIO indicator when the value changes.
+
+**Behavior:** Opens GPIO 71 as input, spawns a loop that reads the pin every 500 ms and, when the value differs from the last read, calls `Ili9488.UI.draw_gpio_indicator/2`.
+
+**API:**
+
+| Function | Description |
+|----------|-------------|
+| `start/1` | Takes the `devs` map from `Ili9488.Driver.start/0` and starts the monitor process. Returns the PID of the spawned process. |
+
+---
+
+## Ili9488.UI
+
+**Role:** Builds the screen layout and keeps the GPIO indicator in sync with hardware.
+
+**Behavior:**
+- **`draw_dashboard/1`** – Draws the full UI: blue background, white textbox outline, "GPIO71" label (drawn with rectangles), and the initial GPIO indicator (OFF = grey).
+- **`draw_gpio_indicator/2`** – Draws a small rectangle under the label: green when GPIO is high (1), grey when low (0). Called by `Ili9488.GPIOMonitor` when the pin state changes.
+
+**Dependencies:** Uses `Ili9488.Driver` for `fill_blue/1` and `draw_rect/6`.
+
+---
+
+## How to run
+
+**Prerequisites:** Nerves firmware with SPI and GPIO (e.g. BB-SPIDEV1 / zola overlay) and the ILI9488 wired to the correct pins.
+
+### Option A – Run manually in IEx
+
+On the device (or `iex -S mix` on host):
+
+```elixir
+# Start driver (opens SPI/GPIO, resets and inits display)
+{:ok, devs} = Ili9488.Driver.start()
+
+# Draw the dashboard (blue screen + textbox + "GPIO71" label + indicator)
+Ili9488.UI.draw_dashboard(devs)
+
+# Start GPIO monitor (polls GPIO 71 every 500 ms and updates the indicator)
+Ili9488.GPIOMonitor.start(devs)
+```
+
+### Option B – One-liner
+
+```elixir
+{:ok, devs} = Ili9488.Driver.start()
+Ili9488.UI.draw_dashboard(devs)
+Ili9488.GPIOMonitor.start(devs)
+```
+
+### Option C – Start from application
+
+To have the display and monitor start on boot, add a worker under `target_children()` in `lib/test_c2/application.ex` that starts the driver, draws the dashboard, then starts the GPIO monitor (e.g. a small GenServer or Task that runs the three steps above).
+
+---
+
+**Note:** GPIO 71 is read every 500 ms; the on-screen indicator turns **green** when high and **grey** when low.
+
+### Testing: change GPIO 71 status manually
+
+Start the display and monitor, then from the same IEx console open GPIO 71 as output and toggle it. The on-screen indicator updates when the monitor (polling every 500 ms) sees the change:
+
+```elixir
+# 1) Start display and monitor
+{:ok, devs} = Ili9488.Driver.start()
+Ili9488.UI.draw_dashboard(devs)
+Ili9488.GPIOMonitor.start(devs)
+
+# 2) Toggle GPIO 71 from the console (indicator goes green/grey)
+{:ok, g} = Circuits.GPIO.open(71, :output)
+Circuits.GPIO.write(g, 1)   # green
+Circuits.GPIO.write(g, 0)   # grey
+Circuits.GPIO.read(g)
+```

--- a/test_c2/lib/test_c2/application.ex
+++ b/test_c2/lib/test_c2/application.ex
@@ -34,9 +34,8 @@ defmodule TestC2.Application do
   else
     defp target_children() do
       [
-        # Children for all targets except host
-        # Starts a worker by calling: Target.Worker.start_link(arg)
-        # {Target.Worker, arg},
+        # LCD backlight (GPIO 116) on at boot
+        {TestC2.LcdBacklight, []},
       ]
     end
   end

--- a/test_c2/lib/test_c2/ili9488_driver.ex
+++ b/test_c2/lib/test_c2/ili9488_driver.ex
@@ -1,0 +1,149 @@
+defmodule Ili9488.Driver do
+  import Bitwise
+
+  @tft_cs   114
+  @tft_dc   76
+  @tft_rst  74
+  @spi_device "spidev1.0"
+
+  @spi_opts [mode: 0, bits_per_word: 8, speed_hz: 20_000_000]
+
+  @width 320
+  @height 480
+
+  @cmd_column_address 0x2A
+  @cmd_page_address   0x2B
+  @cmd_memory_write   0x2C
+
+  def start do
+    {:ok, spi} = Circuits.SPI.open(@spi_device, @spi_opts)
+    {:ok, cs}  = Circuits.GPIO.open(@tft_cs, :output)
+    {:ok, dc}  = Circuits.GPIO.open(@tft_dc, :output)
+    {:ok, rst} = Circuits.GPIO.open(@tft_rst, :output)
+
+    devs = %{spi: spi, cs: cs, dc: dc, rst: rst}
+
+    Circuits.GPIO.write(cs, 1)
+    reset_display(devs)
+    init_display(devs)
+
+    {:ok, devs}
+  end
+
+  defp reset_display(devs) do
+    Circuits.GPIO.write(devs.rst, 0)
+    Process.sleep(50)
+    Circuits.GPIO.write(devs.rst, 1)
+    Process.sleep(120)
+  end
+
+  defp init_display(devs) do
+  # Soft Reset
+  send_command(devs, 0x01)
+  Process.sleep(10)
+
+  # Exit Sleep
+  send_command(devs, 0x11)
+  Process.sleep(120)
+
+  # Display inversion ON
+  send_command(devs, 0x21)
+
+  # Positive Gamma
+  send_command(devs, 0xE0)
+  Enum.each([0x00,0x03,0x09,0x08,0x16,0x0A,0x3F,0x78,0x4C,0x09,0x0A,0x08,0x16,0x1A,0x0F],
+    &send_data(devs, <<&1>>))
+
+  # Negative Gamma
+  send_command(devs, 0xE1)
+  Enum.each([0x00,0x16,0x19,0x03,0x0F,0x05,0x32,0x45,0x46,0x04,0x0E,0x0D,0x35,0x37,0x0F],
+    &send_data(devs, <<&1>>))
+
+  # Power control
+  send_command(devs, 0xC0)
+  Enum.each([0x17,0x15], &send_data(devs, <<&1>>))
+
+  send_command(devs, 0xC1)
+  send_data(devs, <<0x41>>)
+
+  # VCOM
+  send_command(devs, 0xC5)
+  Enum.each([0x00,0x12,0x80], &send_data(devs, <<&1>>))
+
+  # MADCTL
+  send_command(devs, 0x36)
+  send_data(devs, <<0x48>>)
+
+  # RGB666 SPI
+  send_command(devs, 0x3A)
+  send_data(devs, <<0x66>>)
+  Process.sleep(10)
+
+  # Interface control
+  send_command(devs, 0xB0)
+  send_data(devs, <<0x00>>)
+
+  send_command(devs, 0xB1)
+  send_data(devs, <<0xA0>>)
+
+  send_command(devs, 0xB4)
+  send_data(devs, <<0x02>>)
+
+  send_command(devs, 0xB6)
+  Enum.each([0x02,0x02,0x3B], &send_data(devs, <<&1>>))
+
+  send_command(devs, 0xB7)
+  send_data(devs, <<0xC6>>)
+
+  send_command(devs, 0xF7)
+  Enum.each([0xA9,0x51,0x2C,0x82], &send_data(devs, <<&1>>))
+
+  # Display ON
+  send_command(devs, 0x29)
+  Process.sleep(25)
+end
+
+
+  def fill_blue(devs), do: fill_color(devs, <<0, 0, 255>>)
+
+  def fill_color(devs, pixel) do
+    set_window(devs, 0, 0, @width - 1, @height - 1)
+    send_command(devs, @cmd_memory_write)
+    send_pixels(devs, pixel, @width * @height)
+  end
+
+  def draw_rect(devs, x, y, w, h, color) do
+    set_window(devs, x, y, x + w - 1, y + h - 1)
+    send_command(devs, @cmd_memory_write)
+    send_pixels(devs, color, w * h)
+  end
+
+  defp set_window(devs, x1, y1, x2, y2) do
+    send_command(devs, @cmd_column_address)
+    send_data(devs, <<x1>>>8, x1 &&& 0xFF, x2>>>8, x2 &&& 0xFF>>)
+
+    send_command(devs, @cmd_page_address)
+    send_data(devs, <<y1>>>8, y1 &&& 0xFF, y2>>>8, y2 &&& 0xFF>>)
+  end
+
+  defp send_pixels(_devs, _pixel, 0), do: :ok
+  defp send_pixels(devs, pixel, count) do
+    chunk = min(count, 341)
+    send_data(devs, :binary.copy(pixel, chunk))
+    send_pixels(devs, pixel, count - chunk)
+  end
+
+  defp send_command(devs, cmd) do
+    Circuits.GPIO.write(devs.cs, 0)
+    Circuits.GPIO.write(devs.dc, 0)
+    Circuits.SPI.transfer!(devs.spi, <<cmd>>)
+    Circuits.GPIO.write(devs.cs, 1)
+  end
+
+  defp send_data(devs, data) do
+    Circuits.GPIO.write(devs.cs, 0)
+    Circuits.GPIO.write(devs.dc, 1)
+    Circuits.SPI.transfer!(devs.spi, data)
+    Circuits.GPIO.write(devs.cs, 1)
+  end
+end

--- a/test_c2/lib/test_c2/ili9488_driver.ex
+++ b/test_c2/lib/test_c2/ili9488_driver.ex
@@ -40,67 +40,73 @@ defmodule Ili9488.Driver do
   # Init sequence (gamma, power, VCOM, etc.) uses register values from ESP32
   # ILI9488 driver reference. Adjust if colours or brightness need tuning.
   defp init_display(devs) do
-  # Soft Reset
+  # Soft Reset (0x01)
   send_command(devs, 0x01)
   Process.sleep(10)
 
-  # Exit Sleep
+  # Exit Sleep (0x11)
   send_command(devs, 0x11)
   Process.sleep(120)
 
-  # Display inversion ON
+  # Display Inversion ON (0x21) – inverts pixel polarity for correct colours
   send_command(devs, 0x21)
 
-  # Positive Gamma (0xE0) – 15 bytes. Values from ESP32 ILI9488 reference.
+  # --- Positive Gamma Control (0xE0) – 15 bytes, curve for bright levels (ESP32 ref) ---
   send_command(devs, 0xE0)
   Enum.each([0x00,0x03,0x09,0x08,0x16,0x0A,0x3F,0x78,0x4C,0x09,0x0A,0x08,0x16,0x1A,0x0F],
     &send_data(devs, <<&1>>))
 
-  # Negative Gamma (0xE1) – 15 bytes. Values from ESP32 ILI9488 reference.
+  # --- Negative Gamma Control (0xE1) – 15 bytes, curve for dark levels (ESP32 ref) ---
   send_command(devs, 0xE1)
   Enum.each([0x00,0x16,0x19,0x03,0x0F,0x05,0x32,0x45,0x46,0x04,0x0E,0x0D,0x35,0x37,0x0F],
     &send_data(devs, <<&1>>))
 
-  # Power control
+  # --- Power Control 1 (0xC0) – 2 bytes: VRH, VC ---
   send_command(devs, 0xC0)
   Enum.each([0x17,0x15], &send_data(devs, <<&1>>))
 
+  # --- Power Control 2 (0xC1) – 1 byte: BT (step-up factor) ---
   send_command(devs, 0xC1)
   send_data(devs, <<0x41>>)
 
-  # VCOM
+  # --- VCOM Control (0xC5) – 3 bytes: VCOM value for contrast ---
   send_command(devs, 0xC5)
   Enum.each([0x00,0x12,0x80], &send_data(devs, <<&1>>))
 
-  # MADCTL
+  # --- Memory Access Control / MADCTL (0x36) – 0x48 = MX + BGR (orientation + colour order) ---
   send_command(devs, 0x36)
   send_data(devs, <<0x48>>)
 
-  # RGB666 SPI
+  # --- Pixel Format (0x3A) – 0x66 = RGB666, 3 bytes per pixel (18-bit SPI) ---
   send_command(devs, 0x3A)
   send_data(devs, <<0x66>>)
   Process.sleep(10)
 
-  # Interface control
+  # --- Interface Mode Control (0xB0) – 0x00 = SDO not used (3-wire SPI) ---
   send_command(devs, 0xB0)
   send_data(devs, <<0x00>>)
 
+  # --- Frame Rate Control (0xB1) – 0xA0 = nominal frame rate ---
   send_command(devs, 0xB1)
   send_data(devs, <<0xA0>>)
 
+  # --- Display Inversion Control (0xB4) – 0x02 = 2-dot inversion ---
   send_command(devs, 0xB4)
   send_data(devs, <<0x02>>)
 
+  # --- Display Function Control (0xB6) – 3 bytes: scan direction, gate drive ---
   send_command(devs, 0xB6)
   Enum.each([0x02,0x02,0x3B], &send_data(devs, <<&1>>))
 
+  # --- Entry Mode Set (0xB7) – 0xC6 = normal display, low-level input ---
   send_command(devs, 0xB7)
   send_data(devs, <<0xC6>>)
 
+  # --- Adjust Control 3 (0xF7) – 4 bytes: power/colour tweaks (ESP32 ref) ---
   send_command(devs, 0xF7)
   Enum.each([0xA9,0x51,0x2C,0x82], &send_data(devs, <<&1>>))
 
-  # Display ON
+  # --- Display ON (0x29) ---
   send_command(devs, 0x29)
   Process.sleep(25)
 end

--- a/test_c2/lib/test_c2/ili9488_driver.ex
+++ b/test_c2/lib/test_c2/ili9488_driver.ex
@@ -37,6 +37,8 @@ defmodule Ili9488.Driver do
     Process.sleep(120)
   end
 
+  # Init sequence (gamma, power, VCOM, etc.) uses register values from ESP32
+  # ILI9488 driver reference. Adjust if colours or brightness need tuning.
   defp init_display(devs) do
   # Soft Reset
   send_command(devs, 0x01)
@@ -49,12 +51,12 @@ defmodule Ili9488.Driver do
   # Display inversion ON
   send_command(devs, 0x21)
 
-  # Positive Gamma
+  # Positive Gamma (0xE0) – 15 bytes. Values from ESP32 ILI9488 reference.
   send_command(devs, 0xE0)
   Enum.each([0x00,0x03,0x09,0x08,0x16,0x0A,0x3F,0x78,0x4C,0x09,0x0A,0x08,0x16,0x1A,0x0F],
     &send_data(devs, <<&1>>))
 
-  # Negative Gamma
+  # Negative Gamma (0xE1) – 15 bytes. Values from ESP32 ILI9488 reference.
   send_command(devs, 0xE1)
   Enum.each([0x00,0x16,0x19,0x03,0x0F,0x05,0x32,0x45,0x46,0x04,0x0E,0x0D,0x35,0x37,0x0F],
     &send_data(devs, <<&1>>))

--- a/test_c2/lib/test_c2/ili9488_gpio_monitor.ex
+++ b/test_c2/lib/test_c2/ili9488_gpio_monitor.ex
@@ -1,0 +1,20 @@
+defmodule Ili9488.GPIOMonitor do
+  alias Ili9488.UI
+
+  def start(devs) do
+    {:ok, gpio} = Circuits.GPIO.open(71, :input)
+
+    spawn(fn -> loop(devs, gpio, nil) end)
+  end
+
+  defp loop(devs, gpio, last) do
+    state = Circuits.GPIO.read(gpio)
+
+    if state != last do
+      UI.draw_gpio_indicator(devs, state)
+    end
+
+    Process.sleep(500)
+    loop(devs, gpio, state)
+  end
+end

--- a/test_c2/lib/test_c2/ili9488_ui.ex
+++ b/test_c2/lib/test_c2/ili9488_ui.ex
@@ -1,0 +1,78 @@
+defmodule Ili9488.UI do
+  alias Ili9488.Driver
+
+  # -----------------------
+  # Dashboard layout
+  # -----------------------
+  def draw_dashboard(devs) do
+    Driver.fill_blue(devs)
+
+    textbox(devs, 10, 70, 140, 150)
+
+    draw_gpio71_label(devs)
+    draw_gpio_indicator(devs, 0) # initial OFF state
+  end
+
+  # -----------------------
+  # GPIO indicator (UNDER label)
+  # -----------------------
+  def draw_gpio_indicator(devs, state) do
+    color =
+      case state do
+        1 -> <<0, 255, 0>>       # ON
+        _ -> <<80, 80, 80>>      # OFF (grey)
+      end
+
+    # draw below label
+    Driver.draw_rect(devs, 40, 105, 30, 30, color)
+  end
+
+  # -----------------------
+  # Textbox helper
+  # -----------------------
+  defp textbox(devs, x, y, w, h) do
+    color = <<255, 255, 255>>
+
+    Driver.draw_rect(devs, x, y, w, 2, color)
+    Driver.draw_rect(devs, x, y + h - 2, w, 2, color)
+    Driver.draw_rect(devs, x, y, 2, h, color)
+    Driver.draw_rect(devs, x + w - 2, y, 2, h, color)
+  end
+
+  # -----------------------
+  # GPIO71 label
+  # -----------------------
+  defp draw_gpio71_label(devs) do
+  color = <<255, 255, 255>>
+
+  # G
+  Driver.draw_rect(devs, 20, 80, 12, 2, color)
+  Driver.draw_rect(devs, 20, 80, 2, 14, color)
+  Driver.draw_rect(devs, 20, 92, 12, 2, color)
+  Driver.draw_rect(devs, 28, 88, 4, 2, color)
+  Driver.draw_rect(devs, 30, 88, 2, 6, color)
+
+  # P
+  Driver.draw_rect(devs, 38, 80, 2, 14, color)
+  Driver.draw_rect(devs, 38, 80, 10, 2, color)
+  Driver.draw_rect(devs, 48, 80, 2, 6, color)
+  Driver.draw_rect(devs, 38, 86, 10, 2, color)
+
+  # I
+  Driver.draw_rect(devs, 56, 80, 2, 14, color)
+
+  # O
+  Driver.draw_rect(devs, 64, 80, 12, 2, color)
+  Driver.draw_rect(devs, 64, 92, 12, 2, color)
+  Driver.draw_rect(devs, 64, 80, 2, 14, color)
+  Driver.draw_rect(devs, 74, 80, 2, 14, color)
+
+  # 7
+  Driver.draw_rect(devs, 82, 80, 12, 2, color)
+  Driver.draw_rect(devs, 92, 80, 2, 14, color)
+
+  # 1
+  Driver.draw_rect(devs, 100, 80, 2, 14, color)
+  end
+
+end

--- a/test_c2/lib/test_c2/lcd_backlight.ex
+++ b/test_c2/lib/test_c2/lcd_backlight.ex
@@ -1,0 +1,24 @@
+defmodule TestC2.LcdBacklight do
+  @moduledoc """
+  Turns on the LCD backlight (GPIO 116) at application boot and keeps it on.
+  Runs only on device targets (e.g. C2), not on host.
+  """
+  use GenServer
+
+  @gpio_backlight 116
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    case Circuits.GPIO.open(@gpio_backlight, :output) do
+      {:ok, ref} ->
+        Circuits.GPIO.write(ref, 1)
+        {:ok, %{gpio: ref}}
+      {:error, _} = err ->
+        err
+    end
+  end
+end

--- a/test_c2/lib/test_c2/lcd_backlight.ex
+++ b/test_c2/lib/test_c2/lcd_backlight.ex
@@ -17,8 +17,8 @@ defmodule TestC2.LcdBacklight do
       {:ok, ref} ->
         Circuits.GPIO.write(ref, 1)
         {:ok, %{gpio: ref}}
-      {:error, _} = err ->
-        err
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds the ILI9488 TFT display stack and turns on the LCD backlight at boot on device targets.

## New modules
- **Ili9488.Driver** (`ili9488_driver.ex`) – SPI/GPIO setup, reset, init, and drawing (fill, rectangles) for the ILI9488 (320×480, RGB666).
- **Ili9488.GPIOMonitor** (`ili9488_gpio_monitor.ex`) – Monitors GPIO 71 every 500 ms and updates the on-screen indicator (green = high, grey = low).
- **Ili9488.UI** (`ili9488_ui.ex`) – Draws the dashboard: blue background, textbox, "GPIO71" label, and GPIO indicator.
- **TestC2.LcdBacklight** (`lcd_backlight.ex`) – Turns on the LCD backlight (GPIO 116) at application start; supervised on device targets only (not host).

## Other changes
- **Application:** `TestC2.LcdBacklight` added to `target_children()` so the backlight is on at boot on device.
- **Docs:** `docs/ILI9488_MODULES.md` with module overview, API, how to run, and testing GPIO 71 toggle from the console.
- **README:** Boot behavior (LCD backlight), ILI9488 section with link to full docs.

## How to run (IEx)
```
{:ok, devs} = Ili9488.Driver.start()
Ili9488.UI.draw_dashboard(devs)
Ili9488.GPIOMonitor.start(devs)
```
## Toggle GPIO 71 from console to see indicator change:
```
{:ok, g} = Circuits.GPIO.open(71, :output)
Circuits.GPIO.write(g, 1)  # green
Circuits.GPIO.write(g, 0)  # grey
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Directly manipulates SPI/GPIO and adds a supervised boot-time hardware side effect (backlight), which could impact device startup or interfere with pin assignments if misconfigured.
> 
> **Overview**
> Adds an initial ILI9488 TFT display stack: a new `Ili9488.Driver` for SPI/GPIO init + basic drawing, a simple `Ili9488.UI` dashboard (blue background, textbox, GPIO71 label + indicator), and an `Ili9488.GPIOMonitor` process that polls GPIO 71 every 500ms and updates the indicator on changes.
> 
> Enables the LCD backlight at device boot by adding a supervised `TestC2.LcdBacklight` GenServer (GPIO 116 driven high) to `target_children()` (targets only). Documentation is updated with boot/display behavior plus a new `docs/ILI9488_MODULES.md` usage guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74793a71676a2b1cc768ffa2b4e1cacd89de6d32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->