### PR TITLE
Fix SPI1 dts configuration to resolve TFT MISO read and touch issues on V2 board

### DIFF
--- a/package/extra-dts/BB-SPIDEV1-00A0_zola.dts
+++ b/package/extra-dts/BB-SPIDEV1-00A0_zola.dts
@@ -52,8 +52,8 @@
 			/* default state has all gpios released and mode set to uart1 */
 			bb_spi1_pins: pinmux_bb_spi1_pins {
 				pinctrl-single,pins = <
-					0x190 0x13	/* mcasp0_aclkx.spi1_sclk, OUTPUT_PULLUP | MODE3 */
-					0x194 0x33	/* mcasp0_fsx.spi1_d0, INPUT_PULLUP | MODE3 */
+					0x190 0x2B	/* mcasp0_aclkx.spi1_sclk, RXACTIVE=1, pull disabled | MODE3 */
+					0x194 0x2B	/* mcasp0_fsx.spi1_d0, RXACTIVE=1, pull disabled | MODE3 */
 					0x198 0x13	/* mcasp0_axr0.spi1_d1, OUTPUT_PULLUP | MODE3 */
 					//0x1A0 0x13	/* mcasp0_ahclkr.spi1_cs0, OUTPUT_PULLUP | MODE3 */
 					// 0x164 0x12	/* eCAP0_in_PWM0_out.spi1_cs1 OUTPUT_PULLUP | MODE2 */


### PR DESCRIPTION
## Description
Fixed SPI1 communication issues  on the V2 board for LCD display Id read and touch issue, now ILI9488 display register reads
ILI9488 display register reads
Added below changes 
```
0x190 0x2B   /* spi1_sclk  - RXACTIVE=1, pull disabled | MODE3 */
0x194 0x2B   /* spi1_d0    - RXACTIVE=1, pull disabled | MODE3 */
0x198 0x13   /* spi1_d1    - output, MODE3 */
```
Disabled internal pull resistors on SCLK and MISO
Enabled RXACTIVE on input signals

## Verification

- Display ID read correctly: 0x4033
- SPI register reads stable
- Touch controller issue fixed 
- Verified using Saleae logic analyzer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small device-tree pinmux tweak limited to SPI1 signal electrical configuration; main risk is unintended SPI timing/electrical side effects on boards relying on the previous pull-up settings.
> 
> **Overview**
> Updates the `BB-SPIDEV1-00A0_zola.dts` SPI1 pinmux to **enable RXACTIVE and disable internal pulls** on `spi1_sclk` and `spi1_d0` (MISO), replacing the prior pull-up configurations.
> 
> This is intended to stabilize SPI read behavior (e.g., TFT register reads / touch controller reads) by changing the electrical characteristics of the clock and input data lines while leaving the rest of the SPI1 overlay unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2adba186d2e2e4e111099bbac12d2188e9e1d9d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->